### PR TITLE
fix typo in sample/047.txt

### DIFF
--- a/sample/047.txt
+++ b/sample/047.txt
@@ -8,7 +8,7 @@ T
 # 入力例 1
 5
 RGBGB
-GRGRB1 2
+GRGRB
 
 # 出力例 1
 6


### PR DESCRIPTION
いつもありがとうございます！
典型047のサンプル1に余計な数字が入っていたので修正してみました。